### PR TITLE
chore(otel-nestjs-instrumentation): bump version to 0.3.1

### DIFF
--- a/libs/newrelic-nestjs-instrumentation/package.json
+++ b/libs/newrelic-nestjs-instrumentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newrelic-nestjs-instrumentation",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Comprehensive New Relic instrumentation for NestJS applications - SQS, Kafka, HTTP/2, cron jobs and custom protocols",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
## Summary

Bumps `otel-nestjs-instrumentation` package version from `0.1.6` to `0.3.1`.

This aligns the published version with the latest feature changes (shared `startOtelInstrumentationIfAbsent` extraction and related guard/interceptor refactoring).