### PR TITLE
chore(newrelic-nestjs-instrumentation): bump version to 0.3.1

### DIFF
--- a/libs/newrelic-nestjs-instrumentation/package.json
+++ b/libs/newrelic-nestjs-instrumentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newrelic-nestjs-instrumentation",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Comprehensive New Relic instrumentation for NestJS applications - SQS, Kafka, HTTP/2, cron jobs and custom protocols",
   "main": "dist/index.js",
   "files": [

--- a/libs/otel-nestjs-instrumentation/package.json
+++ b/libs/otel-nestjs-instrumentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "otel-nestjs-instrumentation",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "Comprehensive OpenTelemetry instrumentation for NestJS applications - SQS, Kafka, HTTP/2, cron jobs and custom protocols",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Bumps `newrelic-nestjs-instrumentation` package version from `0.3.0` to `0.3.1`.

This aligns the published version with the latest feature changes (shared instrumentation pattern extracted and applied across both otel and newrelic libs).

Also bumps `otel-nestjs-instrumentation` to `0.2.0` to match the release on main.

## Verification

```bash
pnpm --filter newrelic-nestjs-instrumentation test   # all tests pass
pnpm --filter newrelic-nestjs-instrumentation lint   # Prettier + ESLint clean
pnpm --filter newrelic-nestjs-instrumentation build  # compiles without errors
```